### PR TITLE
Add multiple file attachments support for audits

### DIFF
--- a/apps/console/src/hooks/graph/AuditGraph.ts
+++ b/apps/console/src/hooks/graph/AuditGraph.ts
@@ -23,7 +23,7 @@ export const auditNodeQuery = graphql`
         name
         validFrom
         validUntil
-        report {
+        reports {
           id
           filename
           mimeType
@@ -31,7 +31,6 @@ export const auditNodeQuery = graphql`
           downloadUrl
           createdAt
         }
-        reportUrl
         state
         framework {
           id
@@ -60,7 +59,7 @@ export const createAuditMutation = graphql`
           name
           validFrom
           validUntil
-          report {
+          reports {
             id
             filename
           }
@@ -84,7 +83,7 @@ export const updateAuditMutation = graphql`
         name
         validFrom
         validUntil
-        report {
+        reports {
           id
           filename
         }
@@ -209,11 +208,12 @@ export const uploadAuditReportMutation = graphql`
     uploadAuditReport(input: $input) {
       audit {
         id
-        report {
+        reports {
           id
           filename
           downloadUrl
           createdAt
+          size
         }
         updatedAt
       }
@@ -254,11 +254,12 @@ export const deleteAuditReportMutation = graphql`
     deleteAuditReport(input: $input) {
       audit {
         id
-        report {
+        reports {
           id
           filename
           downloadUrl
           createdAt
+          size
         }
         updatedAt
       }
@@ -273,11 +274,12 @@ export const useDeleteAuditReport = () => {
     errorMessage: __("Failed to delete audit report"),
   });
 
-  return (input: { auditId: string }) => {
+  return (input: { auditId: string; reportId: string }) => {
     return mutate({
       variables: {
         input: {
           auditId: input.auditId,
+          reportId: input.reportId,
         },
       },
     });

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphCreateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphCreateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a3c134dcea5981e6a45b623ec2905962>>
+ * @generated SignedSource<<8c9babd8565180782343ee6a2372a7b5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,10 +33,10 @@ export type AuditGraphCreateMutation$data = {
         };
         readonly id: string;
         readonly name: string | null | undefined;
-        readonly report: {
+        readonly reports: ReadonlyArray<{
           readonly filename: string;
           readonly id: string;
-        } | null | undefined;
+        }>;
         readonly state: AuditState;
         readonly validFrom: any | null | undefined;
         readonly validUntil: any | null | undefined;
@@ -118,8 +118,8 @@ v5 = {
           "args": null,
           "concreteType": "Report",
           "kind": "LinkedField",
-          "name": "report",
-          "plural": false,
+          "name": "reports",
+          "plural": true,
           "selections": [
             (v3/*: any*/),
             {
@@ -231,16 +231,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "04d44dfd419c2cde11b0138ca175203f",
+    "cacheID": "e5dfbf7fc8c3d6100c40be15f3ae1f9f",
     "id": null,
     "metadata": {},
     "name": "AuditGraphCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphCreateMutation(\n  $input: CreateAuditInput!\n) {\n  createAudit(input: $input) {\n    auditEdge {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphCreateMutation(\n  $input: CreateAuditInput!\n) {\n  createAudit(input: $input) {\n    auditEdge {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        reports {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4d014b16e02353df354085a151ccfe06";
+(node as any).hash = "ebc50026bdb52dfe7b91ee685b4c1b50";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteReportMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphDeleteReportMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<14b4821bc7eec6b85029d0aae3a3a271>>
+ * @generated SignedSource<<4e95ba3d22dec59dc31a1245cf6b9239>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ConcreteRequest } from 'relay-runtime';
 export type DeleteAuditReportInput = {
   auditId: string;
+  reportId: string;
 };
 export type AuditGraphDeleteReportMutation$variables = {
   input: DeleteAuditReportInput;
@@ -19,12 +20,13 @@ export type AuditGraphDeleteReportMutation$data = {
   readonly deleteAuditReport: {
     readonly audit: {
       readonly id: string;
-      readonly report: {
+      readonly reports: ReadonlyArray<{
         readonly createdAt: any;
         readonly downloadUrl: string | null | undefined;
         readonly filename: string;
         readonly id: string;
-      } | null | undefined;
+        readonly size: number;
+      }>;
       readonly updatedAt: any;
     };
   };
@@ -78,8 +80,8 @@ v2 = [
             "args": null,
             "concreteType": "Report",
             "kind": "LinkedField",
-            "name": "report",
-            "plural": false,
+            "name": "reports",
+            "plural": true,
             "selections": [
               (v1/*: any*/),
               {
@@ -101,6 +103,13 @@ v2 = [
                 "args": null,
                 "kind": "ScalarField",
                 "name": "createdAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "size",
                 "storageKey": null
               }
             ],
@@ -138,16 +147,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "ebceb2fd2a2ffae09bc1578e37dde7e0",
+    "cacheID": "42c70850249e0de8b687d966bf304ca2",
     "id": null,
     "metadata": {},
     "name": "AuditGraphDeleteReportMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphDeleteReportMutation(\n  $input: DeleteAuditReportInput!\n) {\n  deleteAuditReport(input: $input) {\n    audit {\n      id\n      report {\n        id\n        filename\n        downloadUrl\n        createdAt\n      }\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphDeleteReportMutation(\n  $input: DeleteAuditReportInput!\n) {\n  deleteAuditReport(input: $input) {\n    audit {\n      id\n      reports {\n        id\n        filename\n        downloadUrl\n        createdAt\n        size\n      }\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4b5e9537b35458eb3daa313ead9ba655";
+(node as any).hash = "dde614733e46cdf728dd0262476e48bd";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphListQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<145565eb150c67f2f1b3c70fe6f6e748>>
+ * @generated SignedSource<<b3c41b2911c13c75721d6e2816819fbf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -164,8 +164,8 @@ return {
                             "args": null,
                             "concreteType": "Report",
                             "kind": "LinkedField",
-                            "name": "report",
-                            "plural": false,
+                            "name": "reports",
+                            "plural": true,
                             "selections": [
                               (v3/*: any*/),
                               {
@@ -294,12 +294,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d96d2332efb5f43e2dcb09669173ad7e",
+    "cacheID": "cecff91a6026daeec88ec065dd703242",
     "id": null,
     "metadata": {},
     "name": "AuditGraphListQuery",
     "operationKind": "query",
-    "text": "query AuditGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...AuditsPageFragment\n    }\n    id\n  }\n}\n\nfragment AuditsPageFragment on Organization {\n  audits(first: 10) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AuditGraphListQuery(\n  $organizationId: ID!\n) {\n  node(id: $organizationId) {\n    __typename\n    ... on Organization {\n      ...AuditsPageFragment\n    }\n    id\n  }\n}\n\nfragment AuditsPageFragment on Organization {\n  audits(first: 10) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        reports {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fc4103e0e8b03c1b6b8ea07c4adcf095>>
+ * @generated SignedSource<<15d573fedfdc60bfda9104a7067399f4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,15 +26,14 @@ export type AuditGraphNodeQuery$data = {
       readonly id: string;
       readonly name: string;
     };
-    readonly report?: {
+    readonly reports?: ReadonlyArray<{
       readonly createdAt: any;
       readonly downloadUrl: string | null | undefined;
       readonly filename: string;
       readonly id: string;
       readonly mimeType: string;
       readonly size: number;
-    } | null | undefined;
-    readonly reportUrl?: string | null | undefined;
+    }>;
     readonly state?: AuditState;
     readonly updatedAt?: any;
     readonly validFrom?: any | null | undefined;
@@ -101,8 +100,8 @@ v7 = {
   "args": null,
   "concreteType": "Report",
   "kind": "LinkedField",
-  "name": "report",
-  "plural": false,
+  "name": "reports",
+  "plural": true,
   "selections": [
     (v2/*: any*/),
     {
@@ -141,41 +140,34 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "reportUrl",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "state",
   "storageKey": null
 },
-v10 = [
+v9 = [
   (v2/*: any*/),
   (v3/*: any*/)
 ],
-v11 = {
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "Framework",
   "kind": "LinkedField",
   "name": "framework",
   "plural": false,
-  "selections": (v10/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": null
 },
-v12 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": "Organization",
   "kind": "LinkedField",
   "name": "organization",
   "plural": false,
-  "selections": (v10/*: any*/),
+  "selections": (v9/*: any*/),
   "storageKey": null
 },
-v13 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -206,11 +198,10 @@ return {
               (v5/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
-              (v9/*: any*/),
+              (v10/*: any*/),
               (v11/*: any*/),
-              (v12/*: any*/),
               (v6/*: any*/),
-              (v13/*: any*/)
+              (v12/*: any*/)
             ],
             "type": "Audit",
             "abstractKey": null
@@ -252,11 +243,10 @@ return {
               (v5/*: any*/),
               (v7/*: any*/),
               (v8/*: any*/),
-              (v9/*: any*/),
+              (v10/*: any*/),
               (v11/*: any*/),
-              (v12/*: any*/),
               (v6/*: any*/),
-              (v13/*: any*/)
+              (v12/*: any*/)
             ],
             "type": "Audit",
             "abstractKey": null
@@ -267,16 +257,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "eede00ab53ccd396e92b7fe6c1f1c2a2",
+    "cacheID": "a933e3141764b41b606382ee79149720",
     "id": null,
     "metadata": {},
     "name": "AuditGraphNodeQuery",
     "operationKind": "query",
-    "text": "query AuditGraphNodeQuery(\n  $auditId: ID!\n) {\n  node(id: $auditId) {\n    __typename\n    ... on Audit {\n      id\n      name\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n        mimeType\n        size\n        downloadUrl\n        createdAt\n      }\n      reportUrl\n      state\n      framework {\n        id\n        name\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
+    "text": "query AuditGraphNodeQuery(\n  $auditId: ID!\n) {\n  node(id: $auditId) {\n    __typename\n    ... on Audit {\n      id\n      name\n      validFrom\n      validUntil\n      reports {\n        id\n        filename\n        mimeType\n        size\n        downloadUrl\n        createdAt\n      }\n      state\n      framework {\n        id\n        name\n      }\n      organization {\n        id\n        name\n      }\n      createdAt\n      updatedAt\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c07896ae39a7d16b42c7ee4216dc28fa";
+(node as any).hash = "5ca22e478bf672b1e975f7d87e541a20";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphUpdateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4255866a0c7fe3c9c3416fe2603b5f63>>
+ * @generated SignedSource<<73e8f82e9fe691c0f2ce365aacd63a71>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,10 +30,10 @@ export type AuditGraphUpdateMutation$data = {
       };
       readonly id: string;
       readonly name: string | null | undefined;
-      readonly report: {
+      readonly reports: ReadonlyArray<{
         readonly filename: string;
         readonly id: string;
-      } | null | undefined;
+      }>;
       readonly state: AuditState;
       readonly updatedAt: any;
       readonly validFrom: any | null | undefined;
@@ -112,8 +112,8 @@ v3 = [
             "args": null,
             "concreteType": "Report",
             "kind": "LinkedField",
-            "name": "report",
-            "plural": false,
+            "name": "reports",
+            "plural": true,
             "selections": [
               (v1/*: any*/),
               {
@@ -178,16 +178,16 @@ return {
     "selections": (v3/*: any*/)
   },
   "params": {
-    "cacheID": "7257cd170b7441f3ce85966556e00ac3",
+    "cacheID": "d3ba6e0fba9c565c3795245ce94587fd",
     "id": null,
     "metadata": {},
     "name": "AuditGraphUpdateMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      name\n      validFrom\n      validUntil\n      report {\n        id\n        filename\n      }\n      state\n      framework {\n        id\n        name\n      }\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphUpdateMutation(\n  $input: UpdateAuditInput!\n) {\n  updateAudit(input: $input) {\n    audit {\n      id\n      name\n      validFrom\n      validUntil\n      reports {\n        id\n        filename\n      }\n      state\n      framework {\n        id\n        name\n      }\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "7fb5d28c8c5fdffddb1c8926e66965ec";
+(node as any).hash = "18d334ede02b78b2ce65d2e3a110cd77";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/AuditGraphUploadReportMutation.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/AuditGraphUploadReportMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<39001f4e110ade4633319d2e71f1377f>>
+ * @generated SignedSource<<338f694f68fa9860df6745f44e595bf1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,12 +20,13 @@ export type AuditGraphUploadReportMutation$data = {
   readonly uploadAuditReport: {
     readonly audit: {
       readonly id: string;
-      readonly report: {
+      readonly reports: ReadonlyArray<{
         readonly createdAt: any;
         readonly downloadUrl: string | null | undefined;
         readonly filename: string;
         readonly id: string;
-      } | null | undefined;
+        readonly size: number;
+      }>;
       readonly updatedAt: any;
     };
   };
@@ -79,8 +80,8 @@ v2 = [
             "args": null,
             "concreteType": "Report",
             "kind": "LinkedField",
-            "name": "report",
-            "plural": false,
+            "name": "reports",
+            "plural": true,
             "selections": [
               (v1/*: any*/),
               {
@@ -102,6 +103,13 @@ v2 = [
                 "args": null,
                 "kind": "ScalarField",
                 "name": "createdAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "size",
                 "storageKey": null
               }
             ],
@@ -139,16 +147,16 @@ return {
     "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "05229f6e6fb7e64ceaf93c4bb8f144e6",
+    "cacheID": "9208cdb19d5596960d0f9e802b8611b2",
     "id": null,
     "metadata": {},
     "name": "AuditGraphUploadReportMutation",
     "operationKind": "mutation",
-    "text": "mutation AuditGraphUploadReportMutation(\n  $input: UploadAuditReportInput!\n) {\n  uploadAuditReport(input: $input) {\n    audit {\n      id\n      report {\n        id\n        filename\n        downloadUrl\n        createdAt\n      }\n      updatedAt\n    }\n  }\n}\n"
+    "text": "mutation AuditGraphUploadReportMutation(\n  $input: UploadAuditReportInput!\n) {\n  uploadAuditReport(input: $input) {\n    audit {\n      id\n      reports {\n        id\n        filename\n        downloadUrl\n        createdAt\n        size\n      }\n      updatedAt\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1acff19bbb4a2e0eeca934cc90040eda";
+(node as any).hash = "234794dc9feddf589c137bfbe725565d";
 
 export default node;

--- a/apps/console/src/hooks/graph/__generated__/FrameworkGraphNodeQuery.graphql.ts
+++ b/apps/console/src/hooks/graph/__generated__/FrameworkGraphNodeQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8901b5c750861080551542d26c2681d6>>
+ * @generated SignedSource<<ede422d4293262399e0e372e0e4c23d9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -52,6 +52,13 @@ v3 = {
   "args": null,
   "kind": "ScalarField",
   "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
   "storageKey": null
 };
 return {
@@ -116,13 +123,7 @@ return {
             "kind": "InlineFragment",
             "selections": [
               (v3/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "description",
-                "storageKey": null
-              },
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -183,6 +184,7 @@ return {
                             "storageKey": null
                           },
                           (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -228,12 +230,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "29d6f638feb1bb633169abcfe083f5d2",
+    "cacheID": "52e2b1a70e61a4267382869e175ca7cd",
     "id": null,
     "metadata": {},
     "name": "FrameworkGraphNodeQuery",
     "operationKind": "query",
-    "text": "query FrameworkGraphNodeQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    ... on Framework {\n      id\n      name\n      ...FrameworkDetailPageFragment\n    }\n    id\n  }\n}\n\nfragment FrameworkDetailPageFragment on Framework {\n  id\n  name\n  description\n  organization {\n    name\n    id\n  }\n  controls(first: 250, orderBy: {field: SECTION_TITLE, direction: ASC}) {\n    edges {\n      node {\n        id\n        sectionTitle\n        name\n        status\n        exclusionJustification\n      }\n    }\n  }\n}\n"
+    "text": "query FrameworkGraphNodeQuery(\n  $frameworkId: ID!\n) {\n  node(id: $frameworkId) {\n    __typename\n    ... on Framework {\n      id\n      name\n      ...FrameworkDetailPageFragment\n    }\n    id\n  }\n}\n\nfragment FrameworkDetailPageFragment on Framework {\n  id\n  name\n  description\n  organization {\n    name\n    id\n  }\n  controls(first: 250, orderBy: {field: SECTION_TITLE, direction: ASC}) {\n    edges {\n      node {\n        id\n        sectionTitle\n        name\n        description\n        status\n        exclusionJustification\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/apps/console/src/hooks/useTrustCenterQueries.ts
+++ b/apps/console/src/hooks/useTrustCenterQueries.ts
@@ -13,11 +13,11 @@ export interface TrustCenterAudit {
   framework: {
     name: string;
   };
-  report: {
+  reports: {
     id: string;
     filename: string;
     downloadUrl: string | null;
-  } | null;
+  }[];
 }
 
 export interface TrustCenterVendor {
@@ -166,7 +166,7 @@ const TRUST_CENTER_QUERY = `
             framework {
               name
             }
-            report {
+            reports {
               id
               filename
               downloadUrl

--- a/apps/console/src/pages/organizations/audits/AuditsPage.tsx
+++ b/apps/console/src/pages/organizations/audits/AuditsPage.tsx
@@ -56,7 +56,7 @@ const paginatedAuditsFragment = graphql`
           name
           validFrom
           validUntil
-          report {
+          reports {
             id
             filename
           }
@@ -156,12 +156,14 @@ function AuditRow({
       <Td>{dateFormat(entry.validFrom, { year: "numeric", month: "short", day: "numeric" }) || __("Not set")}</Td>
       <Td>{dateFormat(entry.validUntil, { year: "numeric", month: "short", day: "numeric" }) || __("Not set")}</Td>
       <Td>
-        {entry.report ? (
+        {entry.reports && entry.reports.length > 0 ? (
           <div className="flex flex-col">
-            <Badge variant="success">{__("Uploaded")}</Badge>
+            <Badge variant="success">
+              {entry.reports.length === 1 ? __("1 file") : __(`${entry.reports.length} files`)}
+            </Badge>
           </div>
         ) : (
-          <Badge variant="neutral">{__("Not uploaded")}</Badge>
+          <Badge variant="neutral">{__("No files")}</Badge>
         )}
       </Td>
       <Td noLink width={50} className="text-end">

--- a/apps/console/src/pages/organizations/audits/__generated__/AuditsListQuery.graphql.ts
+++ b/apps/console/src/pages/organizations/audits/__generated__/AuditsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0010416e8a5bda346d415bd80fd70dc8>>
+ * @generated SignedSource<<ed5f009e2933c4af8766174a55d75c14>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -225,8 +225,8 @@ return {
                             "args": null,
                             "concreteType": "Report",
                             "kind": "LinkedField",
-                            "name": "report",
-                            "plural": false,
+                            "name": "reports",
+                            "plural": true,
                             "selections": [
                               (v9/*: any*/),
                               {
@@ -355,16 +355,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9d185e504f8c34d5c3fd7211d4e8a2a2",
+    "cacheID": "25d034ed5794ca19a69b309d4e57cbaa",
     "id": null,
     "metadata": {},
     "name": "AuditsListQuery",
     "operationKind": "query",
-    "text": "query AuditsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AuditOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AuditsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AuditsPageFragment_sdb03 on Organization {\n  audits(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        report {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
+    "text": "query AuditsListQuery(\n  $after: CursorKey = null\n  $before: CursorKey = null\n  $first: Int = 10\n  $last: Int = null\n  $orderBy: AuditOrder = null\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...AuditsPageFragment_sdb03\n    id\n  }\n}\n\nfragment AuditsPageFragment_sdb03 on Organization {\n  audits(first: $first, after: $after, last: $last, before: $before, orderBy: $orderBy) {\n    edges {\n      node {\n        id\n        name\n        validFrom\n        validUntil\n        reports {\n          id\n          filename\n        }\n        state\n        framework {\n          id\n          name\n        }\n        createdAt\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n      hasPreviousPage\n      startCursor\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "be8d1f1d8015c16539886bc79c8026f7";
+(node as any).hash = "201ef1912735aed2042656818942951c";
 
 export default node;

--- a/apps/console/src/pages/organizations/audits/__generated__/AuditsPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/audits/__generated__/AuditsPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c09163f7cf7b3953aed77791b0d3dd1>>
+ * @generated SignedSource<<a6d57256494093f98ac69e9ea825557a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,10 +23,10 @@ export type AuditsPageFragment$data = {
         };
         readonly id: string;
         readonly name: string | null | undefined;
-        readonly report: {
+        readonly reports: ReadonlyArray<{
           readonly filename: string;
           readonly id: string;
-        } | null | undefined;
+        }>;
         readonly state: AuditState;
         readonly validFrom: any | null | undefined;
         readonly validUntil: any | null | undefined;
@@ -174,8 +174,8 @@ return {
                   "args": null,
                   "concreteType": "Report",
                   "kind": "LinkedField",
-                  "name": "report",
-                  "plural": false,
+                  "name": "reports",
+                  "plural": true,
                   "selections": [
                     (v1/*: any*/),
                     {
@@ -296,6 +296,6 @@ return {
 };
 })();
 
-(node as any).hash = "be8d1f1d8015c16539886bc79c8026f7";
+(node as any).hash = "201ef1912735aed2042656818942951c";
 
 export default node;

--- a/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkDetailPageFragment.graphql.ts
+++ b/apps/console/src/pages/organizations/frameworks/__generated__/FrameworkDetailPageFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c6e55821a322dceae5408ac3898cfa48>>
+ * @generated SignedSource<<7c40de0ad2ff5a5aecc52e43141b84ad>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type FrameworkDetailPageFragment$data = {
     readonly __id: string;
     readonly edges: ReadonlyArray<{
       readonly node: {
+        readonly description: string;
         readonly exclusionJustification: string | null | undefined;
         readonly id: string;
         readonly name: string;
@@ -51,6 +52,13 @@ v1 = {
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "description",
+  "storageKey": null
 };
 return {
   "argumentDefinitions": [],
@@ -60,13 +68,7 @@ return {
   "selections": [
     (v0/*: any*/),
     (v1/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "description",
-      "storageKey": null
-    },
+    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -126,6 +128,7 @@ return {
                   "storageKey": null
                 },
                 (v1/*: any*/),
+                (v2/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -167,6 +170,6 @@ return {
 };
 })();
 
-(node as any).hash = "c31fd5c0f675d2524f736d69c4ebebe3";
+(node as any).hash = "baec33e39e0c8c921a2391466355468f";
 
 export default node;

--- a/apps/console/src/trust/components/PublicTrustCenterAudits.tsx
+++ b/apps/console/src/trust/components/PublicTrustCenterAudits.tsx
@@ -66,9 +66,10 @@ export function PublicTrustCenterAudits({
         </Thead>
         <Tbody>
           {audits.map((audit) => {
-            const hasReport = audit.report !== null;
-            const downloadUrl = audit.report?.downloadUrl;
-            const reportName = audit.report?.filename || __("Compliance Report");
+            const hasReport = audit.reports && audit.reports.length > 0;
+            const firstReport = audit.reports?.[0];
+            const downloadUrl = firstReport?.downloadUrl;
+            const reportName = firstReport?.filename || __("Compliance Report");
 
             return (
               <Tr key={audit.id}>

--- a/pkg/coredata/audit.go
+++ b/pkg/coredata/audit.go
@@ -32,7 +32,6 @@ type (
 		Name              *string    `db:"name"`
 		OrganizationID    gid.GID    `db:"organization_id"`
 		FrameworkID       gid.GID    `db:"framework_id"`
-		ReportID          *gid.GID   `db:"report_id"`
 		ValidFrom         *time.Time `db:"valid_from"`
 		ValidUntil        *time.Time `db:"valid_until"`
 		State             AuditState `db:"state"`
@@ -71,7 +70,6 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
-	report_id,
 	valid_from,
 	valid_until,
 	state,
@@ -152,7 +150,6 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
-	report_id,
 	valid_from,
 	valid_until,
 	state,
@@ -202,7 +199,6 @@ INSERT INTO audits (
 	tenant_id,
 	organization_id,
 	framework_id,
-	report_id,
 	valid_from,
 	valid_until,
 	state,
@@ -215,7 +211,6 @@ INSERT INTO audits (
 	@tenant_id,
 	@organization_id,
 	@framework_id,
-	@report_id,
 	@valid_from,
 	@valid_until,
 	@state,
@@ -231,7 +226,6 @@ INSERT INTO audits (
 		"tenant_id":            scope.GetTenantID(),
 		"organization_id":      a.OrganizationID,
 		"framework_id":         a.FrameworkID,
-		"report_id":            a.ReportID,
 		"valid_from":           a.ValidFrom,
 		"valid_until":          a.ValidUntil,
 		"state":                a.State,
@@ -257,7 +251,6 @@ func (a *Audit) Update(
 UPDATE audits
 SET
 	name = @name,
-	report_id = @report_id,
 	valid_from = @valid_from,
 	valid_until = @valid_until,
 	state = @state,
@@ -273,7 +266,6 @@ WHERE
 	args := pgx.StrictNamedArgs{
 		"id":                   a.ID,
 		"name":                 a.Name,
-		"report_id":            a.ReportID,
 		"valid_from":           a.ValidFrom,
 		"valid_until":          a.ValidUntil,
 		"state":                a.State,
@@ -369,7 +361,6 @@ WITH audits_by_control AS (
 		a.name,
 		a.organization_id,
 		a.framework_id,
-		a.report_id,
 		a.valid_from,
 		a.valid_until,
 		a.state,
@@ -388,7 +379,6 @@ SELECT
 	name,
 	organization_id,
 	framework_id,
-	report_id,
 	valid_from,
 	valid_until,
 	state,

--- a/pkg/coredata/audit_report.go
+++ b/pkg/coredata/audit_report.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2025 Probo Inc <hello@getprobo.com>.
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+// REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+// AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+// INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+// LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+// OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+// PERFORMANCE OF THIS SOFTWARE.
+
+package coredata
+
+import (
+	"context"
+	"time"
+
+	"github.com/getprobo/probo/pkg/gid"
+	"github.com/jackc/pgx/v5"
+	"go.gearno.de/kit/pg"
+)
+
+type (
+	AuditReport struct {
+		AuditID   gid.GID   `db:"audit_id"`
+		ReportID  gid.GID   `db:"report_id"`
+		CreatedAt time.Time `db:"created_at"`
+	}
+
+	AuditReports []*AuditReport
+)
+
+func (ar AuditReport) Upsert(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+) error {
+	q := `
+INSERT INTO
+    audit_reports (
+        audit_id,
+        report_id,
+        tenant_id,
+        created_at
+    )
+VALUES (
+    @audit_id,
+    @report_id,
+    @tenant_id,
+    @created_at
+)
+ON CONFLICT (audit_id, report_id) DO NOTHING;
+`
+
+	args := pgx.StrictNamedArgs{
+		"audit_id":   ar.AuditID,
+		"report_id":  ar.ReportID,
+		"tenant_id":  scope.GetTenantID(),
+		"created_at": ar.CreatedAt,
+	}
+	_, err := conn.Exec(ctx, q, args)
+	return err
+}
+
+func (ar AuditReport) Delete(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	auditID gid.GID,
+	reportID gid.GID,
+) error {
+	q := `
+DELETE
+FROM
+    audit_reports
+WHERE
+    audit_id = @audit_id
+    AND report_id = @report_id
+    AND tenant_id = @tenant_id;
+`
+
+	args := pgx.StrictNamedArgs{
+		"audit_id":  auditID,
+		"report_id": reportID,
+		"tenant_id": scope.GetTenantID(),
+	}
+	_, err := conn.Exec(ctx, q, args)
+	return err
+}
+
+func (ars *AuditReports) LoadByAuditID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	auditID gid.GID,
+) error {
+	q := `
+SELECT
+    audit_id,
+    report_id,
+    created_at
+FROM
+    audit_reports
+WHERE
+    audit_id = @audit_id
+    AND tenant_id = @tenant_id
+ORDER BY
+    created_at DESC;
+`
+
+	args := pgx.StrictNamedArgs{
+		"audit_id":  auditID,
+		"tenant_id": scope.GetTenantID(),
+	}
+
+	rows, err := conn.Query(ctx, q, args)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var auditReports []*AuditReport
+	for rows.Next() {
+		ar := &AuditReport{}
+		if err := rows.Scan(&ar.AuditID, &ar.ReportID, &ar.CreatedAt); err != nil {
+			return err
+		}
+		auditReports = append(auditReports, ar)
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	*ars = auditReports
+	return nil
+}
+
+func (ar AuditReport) DeleteByAuditID(
+	ctx context.Context,
+	conn pg.Conn,
+	scope Scoper,
+	auditID gid.GID,
+) error {
+	q := `
+DELETE
+FROM
+    audit_reports
+WHERE
+    audit_id = @audit_id
+    AND tenant_id = @tenant_id;
+`
+
+	args := pgx.StrictNamedArgs{
+		"audit_id":  auditID,
+		"tenant_id": scope.GetTenantID(),
+	}
+	_, err := conn.Exec(ctx, q, args)
+	return err
+}

--- a/pkg/coredata/migrations/20250827T101000Z.sql
+++ b/pkg/coredata/migrations/20250827T101000Z.sql
@@ -1,0 +1,17 @@
+-- Create audit_reports junction table to support multiple file attachments per audit
+CREATE TABLE audit_reports (
+    audit_id TEXT NOT NULL REFERENCES audits(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    report_id TEXT NOT NULL REFERENCES reports(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    tenant_id TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    PRIMARY KEY (audit_id, report_id)
+);
+
+-- Migrate existing audit report relationships to the new junction table
+INSERT INTO audit_reports (audit_id, report_id, tenant_id, created_at)
+SELECT id, report_id, organization_id, updated_at
+FROM audits 
+WHERE report_id IS NOT NULL;
+
+-- Remove the report_id column from audits table (will be handled via junction table)
+ALTER TABLE audits DROP COLUMN report_id;

--- a/pkg/server/api/console/v1/schema.graphql
+++ b/pkg/server/api/console/v1/schema.graphql
@@ -1558,8 +1558,7 @@ type Audit implements Node {
   framework: Framework! @goField(forceResolver: true)
   validFrom: Datetime
   validUntil: Datetime
-  report: Report @goField(forceResolver: true)
-  reportUrl: String @goField(forceResolver: true)
+  reports: [Report!]! @goField(forceResolver: true)
   state: AuditState!
 
   controls(
@@ -2762,6 +2761,7 @@ input UploadAuditReportInput {
 
 input DeleteAuditReportInput {
   auditId: ID!
+  reportId: ID!
 }
 
 # Nonconformity Registry input types

--- a/pkg/server/api/console/v1/schema/schema.go
+++ b/pkg/server/api/console/v1/schema/schema.go
@@ -136,8 +136,7 @@ type ComplexityRoot struct {
 		ID                func(childComplexity int) int
 		Name              func(childComplexity int) int
 		Organization      func(childComplexity int) int
-		Report            func(childComplexity int) int
-		ReportURL         func(childComplexity int) int
+		Reports           func(childComplexity int) int
 		ShowOnTrustCenter func(childComplexity int) int
 		State             func(childComplexity int) int
 		UpdatedAt         func(childComplexity int) int
@@ -1393,8 +1392,7 @@ type AuditResolver interface {
 	Organization(ctx context.Context, obj *types.Audit) (*types.Organization, error)
 	Framework(ctx context.Context, obj *types.Audit) (*types.Framework, error)
 
-	Report(ctx context.Context, obj *types.Audit) (*types.Report, error)
-	ReportURL(ctx context.Context, obj *types.Audit) (*string, error)
+	Reports(ctx context.Context, obj *types.Audit) ([]*types.Report, error)
 
 	Controls(ctx context.Context, obj *types.Audit, first *int, after *page.CursorKey, last *int, before *page.CursorKey, orderBy *types.ControlOrderBy, filter *types.ControlFilter) (*types.ControlConnection, error)
 }
@@ -1911,19 +1909,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Audit.Organization(childComplexity), true
 
-	case "Audit.report":
-		if e.complexity.Audit.Report == nil {
+	case "Audit.reports":
+		if e.complexity.Audit.Reports == nil {
 			break
 		}
 
-		return e.complexity.Audit.Report(childComplexity), true
-
-	case "Audit.reportUrl":
-		if e.complexity.Audit.ReportURL == nil {
-			break
-		}
-
-		return e.complexity.Audit.ReportURL(childComplexity), true
+		return e.complexity.Audit.Reports(childComplexity), true
 
 	case "Audit.showOnTrustCenter":
 		if e.complexity.Audit.ShowOnTrustCenter == nil {
@@ -9166,8 +9157,7 @@ type Audit implements Node {
   framework: Framework! @goField(forceResolver: true)
   validFrom: Datetime
   validUntil: Datetime
-  report: Report @goField(forceResolver: true)
-  reportUrl: String @goField(forceResolver: true)
+  reports: [Report!]! @goField(forceResolver: true)
   state: AuditState!
 
   controls(
@@ -10370,6 +10360,7 @@ input UploadAuditReportInput {
 
 input DeleteAuditReportInput {
   auditId: ID!
+  reportId: ID!
 }
 
 # Nonconformity Registry input types
@@ -19657,8 +19648,8 @@ func (ec *executionContext) fieldContext_Audit_validUntil(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Audit_report(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Audit_report(ctx, field)
+func (ec *executionContext) _Audit_reports(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Audit_reports(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -19671,21 +19662,24 @@ func (ec *executionContext) _Audit_report(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Audit().Report(rctx, obj)
+		return ec.resolvers.Audit().Reports(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*types.Report)
+	res := resTmp.([]*types.Report)
 	fc.Result = res
-	return ec.marshalOReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx, field.Selections, res)
+	return ec.marshalNReport2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReportᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Audit_report(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Audit_reports(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Audit",
 		Field:      field,
@@ -19711,47 +19705,6 @@ func (ec *executionContext) fieldContext_Audit_report(_ context.Context, field g
 				return ec.fieldContext_Report_updatedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Report", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Audit_reportUrl(ctx context.Context, field graphql.CollectedField, obj *types.Audit) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Audit_reportUrl(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Audit().ReportURL(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Audit_reportUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Audit",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -20239,10 +20192,8 @@ func (ec *executionContext) fieldContext_AuditEdge_node(_ context.Context, field
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -20767,10 +20718,8 @@ func (ec *executionContext) fieldContext_ComplianceRegistry_audit(_ context.Cont
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -22199,10 +22148,8 @@ func (ec *executionContext) fieldContext_ContinualImprovementRegistry_audit(_ co
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -26315,10 +26262,8 @@ func (ec *executionContext) fieldContext_DeleteAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -39422,10 +39367,8 @@ func (ec *executionContext) fieldContext_NonconformityRegistry_audit(_ context.C
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -47612,10 +47555,8 @@ func (ec *executionContext) fieldContext_UpdateAuditPayload_audit(_ context.Cont
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -49090,10 +49031,8 @@ func (ec *executionContext) fieldContext_UploadAuditReportPayload_audit(_ contex
 				return ec.fieldContext_Audit_validFrom(ctx, field)
 			case "validUntil":
 				return ec.fieldContext_Audit_validUntil(ctx, field)
-			case "report":
-				return ec.fieldContext_Audit_report(ctx, field)
-			case "reportUrl":
-				return ec.fieldContext_Audit_reportUrl(ctx, field)
+			case "reports":
+				return ec.fieldContext_Audit_reports(ctx, field)
 			case "state":
 				return ec.fieldContext_Audit_state(ctx, field)
 			case "controls":
@@ -59372,7 +59311,7 @@ func (ec *executionContext) unmarshalInputDeleteAuditReportInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"auditId"}
+	fieldsInOrder := [...]string{"auditId", "reportId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -59386,6 +59325,13 @@ func (ec *executionContext) unmarshalInputDeleteAuditReportInput(ctx context.Con
 				return it, err
 			}
 			it.AuditID = data
+		case "reportId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("reportId"))
+			data, err := ec.unmarshalNID2githubᚗcomᚋgetproboᚋproboᚋpkgᚋgidᚐGID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ReportID = data
 		}
 	}
 
@@ -63918,49 +63864,19 @@ func (ec *executionContext) _Audit(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Audit_validFrom(ctx, field, obj)
 		case "validUntil":
 			out.Values[i] = ec._Audit_validUntil(ctx, field, obj)
-		case "report":
+		case "reports":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Audit_report(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
+				res = ec._Audit_reports(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
 				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "reportUrl":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Audit_reportUrl(ctx, field, obj)
 				return res
 			}
 
@@ -81354,6 +81270,60 @@ func (ec *executionContext) marshalNRemoveUserPayload2ᚖgithubᚗcomᚋgetprobo
 	return ec._RemoveUserPayload(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNReport2ᚕᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReportᚄ(ctx context.Context, sel ast.SelectionSet, v []*types.Report) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx context.Context, sel ast.SelectionSet, v *types.Report) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Report(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNRequestEvidenceInput2githubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRequestEvidenceInput(ctx context.Context, v any) (types.RequestEvidenceInput, error) {
 	res, err := ec.unmarshalInputRequestEvidenceInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -84390,13 +84360,6 @@ func (ec *executionContext) unmarshalOPeopleOrder2ᚖgithubᚗcomᚋgetproboᚋp
 	}
 	res, err := ec.unmarshalInputPeopleOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOReport2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐReport(ctx context.Context, sel ast.SelectionSet, v *types.Report) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Report(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalORiskFilter2ᚖgithubᚗcomᚋgetproboᚋproboᚋpkgᚋserverᚋapiᚋconsoleᚋv1ᚋtypesᚐRiskFilter(ctx context.Context, v any) (*types.RiskFilter, error) {

--- a/pkg/server/api/console/v1/types/types.go
+++ b/pkg/server/api/console/v1/types/types.go
@@ -63,8 +63,7 @@ type Audit struct {
 	Framework         *Framework          `json:"framework"`
 	ValidFrom         *time.Time          `json:"validFrom,omitempty"`
 	ValidUntil        *time.Time          `json:"validUntil,omitempty"`
-	Report            *Report             `json:"report,omitempty"`
-	ReportURL         *string             `json:"reportUrl,omitempty"`
+	Reports           []*Report           `json:"reports"`
 	State             coredata.AuditState `json:"state"`
 	Controls          *ControlConnection  `json:"controls"`
 	ShowOnTrustCenter bool                `json:"showOnTrustCenter"`
@@ -619,7 +618,8 @@ type DeleteAuditPayload struct {
 }
 
 type DeleteAuditReportInput struct {
-	AuditID gid.GID `json:"auditId"`
+	AuditID  gid.GID `json:"auditId"`
+	ReportID gid.GID `json:"reportId"`
 }
 
 type DeleteAuditReportPayload struct {

--- a/pkg/server/api/trust/v1/v1_resolver.go
+++ b/pkg/server/api/trust/v1/v1_resolver.go
@@ -40,21 +40,17 @@ func (r *auditResolver) Framework(ctx context.Context, obj *types.Audit) (*types
 func (r *auditResolver) Report(ctx context.Context, obj *types.Audit) (*types.Report, error) {
 	trust := r.TrustService(ctx, obj.ID.TenantID())
 
-	audit, err := trust.Audits.Get(ctx, obj.ID)
+	reports, err := trust.Audits.GetReports(ctx, obj.ID)
 	if err != nil {
-		return nil, fmt.Errorf("cannot load audit: %w", err)
+		return nil, fmt.Errorf("cannot load audit reports: %w", err)
 	}
 
-	if audit.ReportID == nil {
+	if len(reports) == 0 {
 		return nil, nil
 	}
 
-	report, err := trust.Reports.Get(ctx, *audit.ReportID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot load report: %w", err)
-	}
-
-	return types.NewReport(report), nil
+	// Return the first report for backward compatibility
+	return types.NewReport(reports[0]), nil
 }
 
 // CreateTrustCenterAccess is the resolver for the createTrustCenterAccess field.


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for multiple file attachments per audit, replacing the previous single-file limitation with a flexible many-to-many system that enhances audit documentation capabilities.

### 🎯 Key Features Delivered
- ✅ **Multiple file uploads** per audit (PDF/DOCX up to 25MB each)
- ✅ **Individual file management** with download/delete actions for each file  
- ✅ **Always-visible upload dropzone** for progressive file additions
- ✅ **File count indicators** in audit list views
- ✅ **Backward compatibility** with automatic data migration
- ✅ **Trust center compatibility** maintained

### 🔧 Technical Implementation

**Database Schema:**
- New `audit_reports` junction table for many-to-many relationships
- Migration script safely transfers existing single-file relationships
- Removes legacy `report_id` column after data migration

**Backend Services:**
- Enhanced `AuditService` with `GetReports()`, updated upload/delete methods
- New `AuditReport` model with full CRUD operations  
- Updated GraphQL schema: `report` → `reports[]`
- All resolvers updated for multiple file handling

**Frontend Experience:**
- `AuditDetailsPage` displays all files in organized list format
- Individual file cards with metadata (name, size, upload date)
- Persistent upload area for adding more files
- Updated audit listings show file counts vs single file status

### 🔄 Migration Strategy
The included database migration (`20250827T101000Z.sql`) will:
1. Create `audit_reports` junction table
2. Migrate all existing `audit.report_id` relationships  
3. Safely remove the old `report_id` column
4. **Runs automatically** when server starts - no manual intervention needed

### 🧪 Test Plan
- [x] TypeScript compilation passes
- [x] GraphQL types generated successfully  
- [x] Go build succeeds
- [x] All SQL queries updated for new schema
- [x] Trust center API maintains backward compatibility
- [ ] End-to-end testing after migration (requires database migration)

### 🎨 User Experience
Users can now:
- Upload multiple audit documents to each audit
- View all attached files with clear file information
- Download any specific file individually
- Delete specific files without affecting others
- Add additional files at any time after initial upload
- See file count summaries in audit list views

🤖 Generated with [Claude Code](https://claude.ai/code)